### PR TITLE
Allow shipper sync to skip corrupted blocks

### DIFF
--- a/cmd/thanos/config.go
+++ b/cmd/thanos/config.go
@@ -203,6 +203,7 @@ type shipperConfig struct {
 	uploadCompacted       bool
 	ignoreBlockSize       bool
 	allowOutOfOrderUpload bool
+	ingoreCorruptedBlocks bool
 	hashFunc              string
 	metaFileName          string
 }
@@ -219,6 +220,11 @@ func (sc *shipperConfig) registerFlag(cmd extkingpin.FlagClause) *shipperConfig 
 			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
 			"about order.").
 		Default("false").Hidden().BoolVar(&sc.allowOutOfOrderUpload)
+	cmd.Flag("shipper.ignore-corrupted-blocks",
+		"If true, shipper will skip corrupted blocks in the given iteration and retry later. This means that some newer blocks might be uploaded sooner than older blocks."+
+			"This can trigger compaction without those blocks and as a result will create an overlap situation. Set it to true if you have vertical compaction enabled and wish to upload blocks as soon as possible without caring"+
+			"about order.").
+		Default("false").Hidden().BoolVar(&sc.ingoreCorruptedBlocks)
 	cmd.Flag("hash-func", "Specify which hash function to use when calculating the hashes of produced files. If no function has been specified, it does not happen. This permits avoiding downloading some files twice albeit at some performance cost. Possible values are: \"\", \"SHA256\".").
 		Default("").EnumVar(&sc.hashFunc, "SHA256", "")
 	cmd.Flag("shipper.meta-file-name", "the file to store shipper metadata in").Default(shipper.DefaultMetaFilename).StringVar(&sc.metaFileName)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -839,7 +839,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+		s := shipper.New(logger, reg, conf.dataDir, bkt, func() labels.Labels { return conf.lset }, metadata.RulerSource, nil, conf.shipper.allowOutOfOrderUpload, conf.shipper.ingoreCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -416,7 +416,7 @@ func runSidecar(
 
 			uploadCompactedFunc := func() bool { return conf.shipper.uploadCompacted }
 			s := shipper.New(logger, reg, conf.tsdb.path, bkt, m.Labels, metadata.SidecarSource,
-				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
+				uploadCompactedFunc, conf.shipper.allowOutOfOrderUpload, conf.shipper.ingoreCorruptedBlocks, metadata.HashFunc(conf.shipper.hashFunc), conf.shipper.metaFileName)
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
 				if uploaded, err := s.Sync(ctx); err != nil {

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -44,7 +44,7 @@ func TestShipper_SyncBlocks_e2e(t *testing.T) {
 		dir := t.TempDir()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, metricsBucket, func() labels.Labels { return extLset }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -212,7 +212,7 @@ func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
 		testutil.Ok(t, p.Restart(context.Background(), logger))
 
 		uploadCompactedFunc := func() bool { return true }
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, metadata.NoneFunc, DefaultMetaFilename)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
@@ -361,7 +361,7 @@ func TestShipper_SyncOverlapBlocks_e2e(t *testing.T) {
 
 	uploadCompactedFunc := func() bool { return true }
 	// Here, the allowOutOfOrderUploads flag is set to true, which allows blocks with overlaps to be uploaded.
-	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, uploadCompactedFunc, true, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	// Creating 2 overlapping blocks - both uploaded when OOO uploads allowed.
 	var (

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -6,16 +6,19 @@ package shipper
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"math"
 	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 
@@ -29,7 +32,7 @@ import (
 func TestShipperTimestamps(t *testing.T) {
 	dir := t.TempDir()
 
-	s := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	// Missing thanos meta file.
 	_, _, err := s.Timestamps()
@@ -122,9 +125,49 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
-	metas, err := shipper.blockMetasFromOldest()
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	metas, failedBlocks, err := shipper.blockMetasFromOldest()
 	testutil.Ok(t, err)
+	testutil.Equals(t, 0, len(failedBlocks))
+	testutil.Equals(t, sort.SliceIsSorted(metas, func(i, j int) bool {
+		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
+	}), true)
+}
+
+func TestIterBlockMetasWhenMissingMeta(t *testing.T) {
+	dir := t.TempDir()
+
+	id1 := ulid.MustNew(1, nil)
+	testutil.Ok(t, os.Mkdir(path.Join(dir, id1.String()), os.ModePerm))
+	testutil.Ok(t, metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id1,
+			MaxTime: 2000,
+			MinTime: 1000,
+			Version: 1,
+		},
+	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id1.String())))
+
+	id2 := ulid.MustNew(2, nil)
+	testutil.Ok(t, os.Mkdir(path.Join(dir, id2.String()), os.ModePerm))
+
+	id3 := ulid.MustNew(3, nil)
+	testutil.Ok(t, os.Mkdir(path.Join(dir, id3.String()), os.ModePerm))
+	testutil.Ok(t, metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id3,
+			MaxTime: 3000,
+			MinTime: 2000,
+			Version: 1,
+		},
+	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
+
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
+	metas, failedBlocks, err := shipper.blockMetasFromOldest()
+	testutil.NotOk(t, err)
+	testutil.Equals(t, 1, len(failedBlocks))
+	testutil.Equals(t, id2.String(), failedBlocks[0])
+	testutil.Equals(t, 2, len(metas))
 	testutil.Equals(t, sort.SliceIsSorted(metas, func(i, j int) bool {
 		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
 	}), true)
@@ -153,9 +196,9 @@ func BenchmarkIterBlockMetas(b *testing.B) {
 	})
 	b.ResetTimer()
 
-	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+	shipper := New(nil, nil, dir, nil, nil, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
-	_, err := shipper.blockMetasFromOldest()
+	_, _, err := shipper.blockMetasFromOldest()
 	testutil.Ok(b, err)
 }
 
@@ -165,7 +208,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())
@@ -196,6 +239,52 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	testutil.Ok(t, err)
 
 	testutil.Equals(t, []string{segmentFile}, meta.Thanos.SegmentFiles)
+}
+
+func TestShipperSkipCorruptedBlocks(t *testing.T) {
+	dir := t.TempDir()
+
+	inmemory := objstore.NewInMemBucket()
+
+	metrics := prometheus.NewRegistry()
+	lbls := labels.FromStrings("test", "test")
+	s := New(nil, metrics, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, true, metadata.NoneFunc, DefaultMetaFilename)
+
+	id1 := ulid.MustNew(1, nil)
+	blockDir1 := path.Join(dir, id1.String())
+	chunksDir1 := path.Join(blockDir1, block.ChunksDirname)
+	testutil.Ok(t, os.MkdirAll(chunksDir1, os.ModePerm))
+	testutil.Ok(t, metadata.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id1,
+			MaxTime: 2000,
+			MinTime: 1000,
+			Version: 1,
+			Stats: tsdb.BlockStats{
+				NumSamples: 1000, // Not really, but shipper needs nonzero value.
+			},
+		},
+	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id1.String())))
+	testutil.Ok(t, os.WriteFile(filepath.Join(blockDir1, "index"), []byte("index file"), 0666))
+	segmentFile := "00001"
+	testutil.Ok(t, os.WriteFile(filepath.Join(chunksDir1, segmentFile), []byte("hello world"), 0666))
+
+	id2 := ulid.MustNew(2, nil)
+	blockDir2 := path.Join(dir, id2.String())
+	chunksDir2 := path.Join(blockDir2, block.ChunksDirname)
+	testutil.Ok(t, os.MkdirAll(chunksDir2, os.ModePerm))
+	testutil.Ok(t, os.WriteFile(filepath.Join(blockDir2, "index"), []byte("index file"), 0666))
+	testutil.Ok(t, os.WriteFile(filepath.Join(chunksDir2, segmentFile), []byte("hello world"), 0666))
+
+	uploaded, err := s.Sync(context.Background())
+	testutil.NotOk(t, err)
+	testutil.Equals(t, 1, uploaded)
+
+	testutil.Ok(t, promtest.GatherAndCompare(metrics, strings.NewReader(`
+				# HELP thanos_shipper_upload_failures_total Total number of block upload failures
+				# TYPE thanos_shipper_upload_failures_total counter
+				thanos_shipper_upload_failures_total{} 1
+				`), `thanos_shipper_upload_failures_total`))
 }
 
 func TestReadMetaFile(t *testing.T) {
@@ -235,7 +324,7 @@ func TestShipperExistingThanosLabels(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 
 	lbls := labels.FromStrings("test", "test")
-	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, metadata.NoneFunc, DefaultMetaFilename)
+	s := New(nil, nil, dir, inmemory, func() labels.Labels { return lbls }, metadata.TestSource, nil, false, false, metadata.NoneFunc, DefaultMetaFilename)
 
 	id := ulid.MustNew(1, nil)
 	id2 := ulid.MustNew(2, nil)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
